### PR TITLE
아폴로 좌표계에서 유니티 좌표계로 변환하는 API 구현

### DIFF
--- a/Assets/Scripts/Api/Commands/ConvertApolloPositionToWorldPosition.cs
+++ b/Assets/Scripts/Api/Commands/ConvertApolloPositionToWorldPosition.cs
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2019 LG Electronics, Inc.
+ *
+ * This software contains code licensed as described in LICENSE.
+ *
+ */
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using SimpleJSON;
+using Simulator.Map;
+
+namespace Simulator.Api.Commands
+{
+    class ConvertApolloPositionToWorldPosition : ICommand
+    {
+        public string Name => "simulator/convert_apollo_point";
+
+        public void Execute(JSONNode args)
+        {
+            var position = args["position"].ReadVector2();
+
+            MapOrigin mapOrigin = MapOrigin.Find();
+            Debug.Assert(SimulatorManager.Instance.MapManager != null);
+            // Get any point on any lane to get the y value
+            Vector3 anyPosOnUnity = SimulatorManager.Instance.MapManager.GetLane(0).mapWorldPositions[0];
+
+            Vector3 unityPos = new Vector3(
+                    (double)-position.y + mapOrigin.OriginNorthing,
+                    anyPosOnUnity.y,
+                    (double)position.x - mapOrigin.OriginEasting
+            );
+
+            var result = new JSONObject();
+            result.Add("position", unityPos);
+
+            var api = ApiManager.Instance;
+            api.SendResult(this, result);
+        }
+    }
+}

--- a/Assets/Scripts/Api/Commands/ConvertApolloPositionToWorldPosition.cs.meta
+++ b/Assets/Scripts/Api/Commands/ConvertApolloPositionToWorldPosition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fa3ba75eefeefa60da8306471c6060e7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
아폴로 좌표 `(x, y)` 를 유니티 좌표계 `(x', y', z')` 으로 변환하는 API를 구현합니다