### PR TITLE
레코드 영상 이름을 설정할 수 있도록 수정합니다

### DIFF
--- a/Assets/Scripts/Api/Commands/Run.cs
+++ b/Assets/Scripts/Api/Commands/Run.cs
@@ -42,7 +42,12 @@ namespace Simulator.Api.Commands
                 api.FrameLimit = 0;
             }
 
-            sim.AnalysisManager.AnalysisInit();
+            string filename = args["filename"].Value;
+            if (string.IsNullOrEmpty(filename))
+            {
+                filename = null;
+            }
+            sim.AnalysisManager.AnalysisInit(filename);
         }
     }
 }

--- a/Assets/Scripts/Managers/AnalysisManager.cs
+++ b/Assets/Scripts/Managers/AnalysisManager.cs
@@ -88,7 +88,7 @@ namespace Simulator.Analysis
         {
             if (!SimulatorManager.Instance.IsAPI)
             {
-                AnalysisInit();
+                AnalysisInit(null);
             }
             Loader.Instance.Network.MessagesManager?.RegisterObject(this);
         }
@@ -124,7 +124,7 @@ namespace Simulator.Analysis
             }
         }
 
-        public void AnalysisInit()
+        public void AnalysisInit(string filename)
         {
             if (Init)
             {
@@ -166,7 +166,14 @@ namespace Simulator.Analysis
                     var sensorType = sensorBase.GetType().GetCustomAttribute<SensorType>();
                     if (sensorType.Name == "Video Recording")
                     {
-                        sensorBase.GetType().GetMethod("StartRecording").Invoke(sensorBase, new object[] { null });
+                        if (filename == null)
+                        {
+                            sensorBase.GetType().GetMethod("StartRecording").Invoke(sensorBase, new object[] { null });
+                        }
+                        else
+                        {
+                            sensorBase.GetType().GetMethod("StartRecording").Invoke(sensorBase, new object[] { filename });
+                        }
                     }
                 });
             }


### PR DESCRIPTION
`AnalysisInit()` 함수에서 비디오레코딩센서 파라미터를 null로 넘겨 uuid로 이름이 설정되던 것을 수정합니다